### PR TITLE
Add repo-specific whitesource/mend settings

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,6 @@
+{
+    "settingsInheritedFrom": "appcues/whitesource-config@main",
+    "remediateSettings": {
+        "enableRenovate": false
+    }
+}


### PR DESCRIPTION
I don't want all the WSS PRs cluttering things up when we make this repo public. A lot of the recommendations are at odds with what expo expects. For example, I updated the versions and then expo wasn't happy:

```sh
$ npx expo install --fix
Some dependencies are incompatible with the installed expo version:
  expo-font@11.6.0 - expected version: ~11.4.0
  expo-linear-gradient@12.5.0 - expected version: ~12.3.0
  expo-splash-screen@0.22.0 - expected version: ~0.20.5
  expo-status-bar@1.7.1 - expected version: ~1.6.0
  expo-system-ui@2.6.0 - expected version: ~2.4.0
  expo-web-browser@12.5.0 - expected version: ~12.3.2
  react-native-gesture-handler@2.13.4 - expected version: ~2.12.0
  react-native-safe-area-context@4.7.4 - expected version: 4.6.3
  react-native-screens@3.27.0 - expected version: ~3.22.0
  react-native-svg@13.14.0 - expected version: 13.9.0
Your project may not work correctly until you install the correct versions of the packages.

```