### PR TITLE
Add localization support

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,6 +30,7 @@
         "usesNonExemptEncryption": false
       },
       "infoPlist": {
+        "CFBundleDisplayName": "Appcues",
         "CFBundleAllowMixedLocalizations": true,
         "AppcuesUniversalLinkHostAllowList": [],
         "UIAppFonts": [

--- a/app.json
+++ b/app.json
@@ -30,6 +30,7 @@
         "usesNonExemptEncryption": false
       },
       "infoPlist": {
+        "CFBundleAllowMixedLocalizations": true,
         "AppcuesUniversalLinkHostAllowList": [],
         "UIAppFonts": [
           "Mulish-Black.ttf",
@@ -74,7 +75,8 @@
             "buildToolsVersion": "34.0.0"
           }
         }
-      ]
+      ],
+      "expo-localization"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -15,10 +15,12 @@ import PrimaryButton from '../../components/PrimaryButton';
 import { Text } from '../../components/Themed';
 import { color, gradient, shadow } from '../../constants/Brand';
 import { useAuth } from '../../context/auth';
+import { useLocale } from '../../context/locale';
 
 export default function SignIn() {
   const colorScheme = useColorScheme();
   const { signIn } = useAuth();
+  const { language, strings } = useLocale();
   const [emailAddress, onChangeEmailAddress] = useState('');
   const [canShowError, setCanShowError] = useState(false);
 
@@ -65,11 +67,11 @@ export default function SignIn() {
                 : styles.contentBoxDark,
             ]}
           >
-            <Text style={styles.title}>Mobile Pattern Showcase</Text>
+            <Text style={styles.title}>{strings[language].signIn.title}</Text>
             <OutlinedTextInput
               onChangeText={onChangeEmailAddress}
               onBlur={() => setCanShowError(true)}
-              placeholder="Work email"
+              placeholder={strings[language].signIn.input}
               value={emailAddress}
               keyboardType="email-address"
               textContentType="emailAddress"
@@ -81,10 +83,13 @@ export default function SignIn() {
             />
             {canShowError && !isValid() && (
               <Text style={styles.errorText}>
-                Please enter your email address.
+                {strings[language].signIn.inputError}
               </Text>
             )}
-            <PrimaryButton onPress={submit} title="Continue" />
+            <PrimaryButton
+              onPress={submit}
+              title={strings[language].signIn.button}
+            />
           </View>
         </View>
       </KeyboardAvoidingView>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { Tabs } from 'expo-router';
 
 import { useThemeColor } from '../../components/Themed';
+import { useLocale } from '../../context/locale';
 
 /**
  * You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
@@ -15,6 +16,7 @@ function TabBarIcon(props: {
 
 export default function TabLayout() {
   const themedBackgroundColor = useThemeColor('tabBarBackground');
+  const { language, strings } = useLocale();
 
   return (
     <Tabs
@@ -33,7 +35,7 @@ export default function TabLayout() {
         name="patterns"
         options={{
           headerShown: false,
-          title: 'Patterns',
+          title: strings[language].tabs.patterns,
           tabBarIcon: ({ color }) => <TabBarIcon name="book" color={color} />,
           tabBarTestID: 'patterns-tab',
         }}
@@ -42,7 +44,7 @@ export default function TabLayout() {
         name="examples"
         options={{
           headerShown: false,
-          title: 'Examples',
+          title: strings[language].tabs.examples,
           tabBarIcon: ({ color }) => <TabBarIcon name="gift" color={color} />,
           tabBarTestID: 'examples-tab',
         }}
@@ -51,7 +53,7 @@ export default function TabLayout() {
         name="preview"
         options={{
           headerShown: false,
-          title: 'Preview',
+          title: strings[language].tabs.preview,
           tabBarIcon: ({ color }) => <TabBarIcon name="eye" color={color} />,
           tabBarTestID: 'preview-tab',
         }}
@@ -60,7 +62,7 @@ export default function TabLayout() {
         name="more"
         options={{
           headerShown: false,
-          title: 'More',
+          title: strings[language].tabs.more,
           tabBarIcon: ({ color }) => (
             <TabBarIcon name="ellipsis-h" color={color} />
           ),

--- a/app/(tabs)/examples/_layout.tsx
+++ b/app/(tabs)/examples/_layout.tsx
@@ -1,10 +1,12 @@
 import { Stack } from 'expo-router';
 
 import { useThemeColor } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function ExamplesLayout() {
   const themedForegroundColor = useThemeColor('primaryForeground');
   const themedBackgroundColor = useThemeColor('tabBarBackground');
+  const { language, strings } = useLocale();
 
   return (
     <Stack
@@ -25,7 +27,7 @@ export default function ExamplesLayout() {
       <Stack.Screen
         name="index"
         options={{
-          title: 'Examples',
+          title: strings[language].tabs.examples,
         }}
       />
       <Stack.Screen

--- a/app/(tabs)/more/_layout.tsx
+++ b/app/(tabs)/more/_layout.tsx
@@ -1,10 +1,12 @@
 import { Stack } from 'expo-router';
 
 import { useThemeColor } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function MoreLayout() {
   const themedForegroundColor = useThemeColor('primaryForeground');
   const themedBackgroundColor = useThemeColor('tabBarBackground');
+  const { language, strings } = useLocale();
 
   return (
     <Stack
@@ -25,7 +27,7 @@ export default function MoreLayout() {
       <Stack.Screen
         name="index"
         options={{
-          title: 'More',
+          title: strings[language].tabs.more,
         }}
       />
     </Stack>

--- a/app/(tabs)/more/index.tsx
+++ b/app/(tabs)/more/index.tsx
@@ -8,9 +8,11 @@ import PrimaryButton from '../../../components/PrimaryButton';
 import { ScrollView, Text, View } from '../../../components/Themed';
 import { shadow } from '../../../constants/Brand';
 import { useAuth } from '../../../context/auth';
+import { useLocale } from '../../../context/locale';
 
 export default function Examples() {
   const { email, signOut } = useAuth();
+  const { language, strings } = useLocale();
 
   return (
     <ScrollView>
@@ -25,7 +27,7 @@ export default function Examples() {
           <PlainView>
             <Text style={styles.email}>{email}</Text>
             <TouchableOpacity onPress={() => signOut()}>
-              <Text style={styles.link}>Sign Out</Text>
+              <Text style={styles.link}>{strings[language].more.signOut}</Text>
             </TouchableOpacity>
           </PlainView>
         </PlainView>
@@ -35,15 +37,12 @@ export default function Examples() {
         level="secondaryBackground"
         testID="debugger-card"
       >
-        <Text>
-          The Appcues debugger is an in-app overlay that provides debug
-          information in an accessible manner.
-        </Text>
+        <Text>{strings[language].more.debugger}</Text>
         <PrimaryButton
           onPress={() => {
             AppcuesWrapper.debug();
           }}
-          title="Launch the debugger"
+          title={strings[language].more.debuggerButton}
         />
       </View>
       <View
@@ -52,10 +51,9 @@ export default function Examples() {
         testID="colophon-card"
       >
         <Text style={styles.colophonText}>
-          This app is created using React Native, Expo, and the Appcues Mobile
-          SDK.{'\n'}
+          {strings[language].more.colophon + '\n'}
           <Link href="https://github.com/appcues/mobile-pattern-showcase-app">
-            MIT Licensed and source available.
+            {strings[language].more.sourceLink}
           </Link>
         </Text>
       </View>

--- a/app/(tabs)/patterns/_layout.tsx
+++ b/app/(tabs)/patterns/_layout.tsx
@@ -1,10 +1,12 @@
 import { Stack } from 'expo-router';
 
 import { useThemeColor } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function PatternsLayout() {
   const themedForegroundColor = useThemeColor('primaryForeground');
   const themedBackgroundColor = useThemeColor('tabBarBackground');
+  const { language, strings } = useLocale();
 
   return (
     <Stack
@@ -25,25 +27,25 @@ export default function PatternsLayout() {
       <Stack.Screen
         name="index"
         options={{
-          title: 'Patterns',
+          title: strings[language].tabs.patterns,
         }}
       />
       <Stack.Screen
         name="modals"
         options={{
-          title: 'Modals',
+          title: strings[language].modals.title,
         }}
       />
       <Stack.Screen
         name="tooltips"
         options={{
-          title: 'Tooltips',
+          title: strings[language].tooltips.title,
         }}
       />
       <Stack.Screen
         name="embeds"
         options={{
-          title: 'Embeds',
+          title: strings[language].embeds.title,
         }}
       />
     </Stack>

--- a/app/(tabs)/patterns/embeds.tsx
+++ b/app/(tabs)/patterns/embeds.tsx
@@ -3,14 +3,17 @@ import { StyleSheet } from 'react-native';
 import * as AppcuesWrapper from '../../../components/AppcuesWrapper';
 import Overview from '../../../components/Overview';
 import { ScrollView, Text } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function Embeds() {
+  const { language, strings } = useLocale();
+
   return (
     <ScrollView>
       <AppcuesWrapper.WrappedAppcuesFrameView frameID="embeds-banner" />
       <Overview
-        title="Inject seamless-looking experiences inline alongside your other app content."
-        callToAction="See an embed in action"
+        title={strings[language].tooltips.overview}
+        callToAction={strings[language].tooltips.callToAction}
         testID="embeds-trigger-button"
         onPress={() => {
           AppcuesWrapper.track('show-embed');

--- a/app/(tabs)/patterns/index.tsx
+++ b/app/(tabs)/patterns/index.tsx
@@ -4,45 +4,37 @@ import { FlatList, ImageSourcePropType, StyleSheet } from 'react-native';
 import { WrappedAppcuesFrameView } from '../../../components/AppcuesWrapper';
 import PatternCard from '../../../components/PatternCard';
 import { View } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 type ItemData = {
-  slug: string;
-  title: string;
-  subtitle: string;
+  slug: 'modals' | 'tooltips' | 'embeds';
   image: ImageSourcePropType;
 };
 
 const DATA: ItemData[] = [
   {
     slug: 'modals',
-    title: 'Modals',
-    subtitle:
-      'Use partial and full-screen takeovers to convey branded information.',
     image: require('../../../assets/images/modals.png'),
   },
   {
     slug: 'tooltips',
-    title: 'Tooltips',
-    subtitle:
-      'Highlight specific app elements to draw user attention and nudge action.',
     image: require('../../../assets/images/tooltips.png'),
   },
   {
     slug: 'embeds',
-    title: 'Embeds',
-    subtitle:
-      'Inject seamless-looking experiences inline alongside your other app content.',
     image: require('../../../assets/images/embeds.png'),
   },
 ];
 
 export default function Patterns() {
+  const { language, strings } = useLocale();
+
   const renderItem = ({ item }: { item: ItemData }) => {
     return (
       <PatternCard
         image={item.image}
-        title={item.title}
-        subtitle={item.subtitle}
+        title={strings[language].patterns.list[item.slug].title}
+        subtitle={strings[language].patterns.list[item.slug].subtitle}
         onPress={() => router.push(`/patterns/${item.slug}`)}
         testID={`${item.slug}-card`}
         style={{

--- a/app/(tabs)/patterns/modals.tsx
+++ b/app/(tabs)/patterns/modals.tsx
@@ -3,13 +3,16 @@ import { StyleSheet } from 'react-native';
 import * as AppcuesWrapper from '../../../components/AppcuesWrapper';
 import Overview from '../../../components/Overview';
 import { ScrollView, Text } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function Modals() {
+  const { language, strings } = useLocale();
+
   return (
     <ScrollView>
       <Overview
-        title="Use partial and full-screen takeovers to convey branded information."
-        callToAction="See a modal in action"
+        title={strings[language].modals.overview}
+        callToAction={strings[language].modals.callToAction}
         testID="modals-trigger-button"
         onPress={() => {
           AppcuesWrapper.track('show-modal');

--- a/app/(tabs)/patterns/tooltips.tsx
+++ b/app/(tabs)/patterns/tooltips.tsx
@@ -3,13 +3,16 @@ import { StyleSheet } from 'react-native';
 import * as AppcuesWrapper from '../../../components/AppcuesWrapper';
 import Overview from '../../../components/Overview';
 import { ScrollView, Text } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function Tooltips() {
+  const { language, strings } = useLocale();
+
   return (
     <ScrollView>
       <Overview
-        title="Highlight specific app elements to draw user attention and nudge action."
-        callToAction="See tooltips in action"
+        title={strings[language].tooltips.overview}
+        callToAction={strings[language].tooltips.callToAction}
         testID="tooltips-trigger-button"
         onPress={() => {
           AppcuesWrapper.track('show-tooltip');

--- a/app/(tabs)/preview/_layout.tsx
+++ b/app/(tabs)/preview/_layout.tsx
@@ -1,10 +1,12 @@
 import { Stack } from 'expo-router';
 
 import { useThemeColor } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function PreviewLayout() {
   const themedForegroundColor = useThemeColor('primaryForeground');
   const themedBackgroundColor = useThemeColor('tabBarBackground');
+  const { language, strings } = useLocale();
 
   return (
     <Stack
@@ -25,13 +27,13 @@ export default function PreviewLayout() {
       <Stack.Screen
         name="index"
         options={{
-          title: 'Preview',
+          title: strings[language].tabs.preview,
         }}
       />
       <Stack.Screen
         name="[...preview]"
         options={{
-          title: 'Preview',
+          title: strings[language].tabs.preview,
         }}
       />
     </Stack>

--- a/app/(tabs)/preview/index.tsx
+++ b/app/(tabs)/preview/index.tsx
@@ -1,22 +1,19 @@
 import { Image, StyleSheet } from 'react-native';
 
 import { Text, View } from '../../../components/Themed';
+import { useLocale } from '../../../context/locale';
 
 export default function Preview() {
+  const { language, strings } = useLocale();
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>
-        The Appcues Mobile Builder allows you to easily use a deep link to
-        preview your flows in your app:
-      </Text>
+      <Text style={styles.title}>{strings[language].preview.p1}</Text>
       <Image
         source={require('../../../assets/images/flow-preview-modal.png')}
         style={styles.image}
       />
-      <Text style={styles.title}>
-        If you don't have the Appcues Mobile SDK installed in your app, this app
-        allows you to test out your flow.
-      </Text>
+      <Text style={styles.title}>{strings[language].preview.p2}</Text>
     </View>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,7 @@ import { useColorScheme } from 'react-native';
 
 import * as AppcuesWrapper from '../components/AppcuesWrapper';
 import { AuthProvider } from '../context/auth';
+import { LocaleProvider } from '../context/locale';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -113,9 +114,11 @@ function RootLayoutNav() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <AuthProvider>
-        <Slot />
-      </AuthProvider>
+      <LocaleProvider>
+        <AuthProvider>
+          <Slot />
+        </AuthProvider>
+      </LocaleProvider>
     </ThemeProvider>
   );
 }

--- a/configure-app-fonts.sh
+++ b/configure-app-fonts.sh
@@ -3,6 +3,11 @@
 # Assumes that source font files are located in ./assets/fonts
 
 if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+  # Note: the following 3 lines updating the app name is unrelated to font configuration and should not be copied.
+  echo "Update app name"
+  # on macos: -i ''
+  sed -i 's/Showcase/Appcues/' android/app/src/main/res/values/strings.xml
+
   echo "Copy fonts to resources"
   mkdir -p ./android/app/src/main/assets/fonts && cp ./assets/fonts/*.ttf "$_"
   ls -1 ./android/app/src/main/assets/fonts

--- a/context/locale.tsx
+++ b/context/locale.tsx
@@ -1,0 +1,49 @@
+import * as Localization from 'expo-localization';
+import React, { PropsWithChildren } from 'react';
+
+import enStrings from '../languages/english.json';
+import frStrings from '../languages/french.json';
+
+// This is an object so we can do "keyof typeof" below. Otherwise an array would make sense.
+const supportedLanguages = {
+  en: 'English',
+  fr: 'French',
+};
+
+type SupportedLanguage = keyof typeof supportedLanguages;
+
+type LocaleContextType = {
+  language: SupportedLanguage;
+  strings: {
+    [key in SupportedLanguage]: typeof enStrings;
+  };
+};
+
+const strings: LocaleContextType['strings'] = {
+  en: enStrings,
+  fr: frStrings,
+};
+
+const LocaleContext = React.createContext<LocaleContextType>(null!);
+
+export function useLocale() {
+  return React.useContext(LocaleContext);
+}
+
+export function LocaleProvider(props: PropsWithChildren) {
+  const locales = Localization.useLocales();
+
+  // This is a bit wonky, but we want to find the first user-preferred languageCode
+  // that's one of our supported ones, otherwise fall back to 'en' in a type safe way.
+  const language = (locales.find((locale) => {
+    return (
+      supportedLanguages[locale.languageCode as SupportedLanguage] !== undefined
+    );
+  })?.languageCode ?? 'en') as SupportedLanguage;
+
+  return (
+    <LocaleContext.Provider value={{ language, strings }}>
+      {props.children}
+    </LocaleContext.Provider>
+  );
+}

--- a/context/locale.tsx
+++ b/context/locale.tsx
@@ -4,24 +4,20 @@ import React, { PropsWithChildren } from 'react';
 import enStrings from '../languages/english.json';
 import frStrings from '../languages/french.json';
 
-// This is an object so we can do "keyof typeof" below. Otherwise an array would make sense.
-const supportedLanguages = {
-  en: 'English',
-  fr: 'French',
+const strings = {
+  en: enStrings,
+  fr: frStrings,
 };
 
-type SupportedLanguage = keyof typeof supportedLanguages;
+const defaultLanguage: SupportedLanguage = 'en';
+
+type SupportedLanguage = keyof typeof strings;
 
 type LocaleContextType = {
   language: SupportedLanguage;
   strings: {
     [key in SupportedLanguage]: typeof enStrings;
   };
-};
-
-const strings: LocaleContextType['strings'] = {
-  en: enStrings,
-  fr: frStrings,
 };
 
 const LocaleContext = React.createContext<LocaleContextType>(null!);
@@ -36,10 +32,8 @@ export function LocaleProvider(props: PropsWithChildren) {
   // This is a bit wonky, but we want to find the first user-preferred languageCode
   // that's one of our supported ones, otherwise fall back to 'en' in a type safe way.
   const language = (locales.find((locale) => {
-    return (
-      supportedLanguages[locale.languageCode as SupportedLanguage] !== undefined
-    );
-  })?.languageCode ?? 'en') as SupportedLanguage;
+    return strings[locale.languageCode as SupportedLanguage] !== undefined;
+  })?.languageCode ?? defaultLanguage) as SupportedLanguage;
 
   return (
     <LocaleContext.Provider value={{ language, strings }}>

--- a/languages/english.json
+++ b/languages/english.json
@@ -1,0 +1,56 @@
+{
+  "signIn": {
+    "title": "Mobile Pattern Showcase",
+    "input": "Work email",
+    "inputError": "Please enter your email address.",
+    "button": "Continue"
+  },
+  "tabs": {
+    "patterns": "Patterns",
+    "examples": "Examples",
+    "preview": "Preview",
+    "more": "More"
+  },
+  "patterns": {
+    "list": {
+      "modals": {
+        "title": "Modals",
+        "subtitle": "Use partial and full-screen takeovers to convey branded information."
+      },
+      "tooltips": {
+        "title": "Tooltips",
+        "subtitle": "Highlight specific app elements to draw user attention and nudge action."
+      },
+      "embeds": {
+        "title": "Embeds",
+        "subtitle": "Inject seamless-looking experiences inline alongside your other app content."
+      }
+    }
+  },
+  "modals": {
+    "title": "Modals",
+    "overview": "Use partial and full-screen takeovers to convey branded information.",
+    "callToAction": "See a modal in action"
+  },
+  "tooltips": {
+    "title": "Tooltips",
+    "overview": "Highlight specific app elements to draw user attention and nudge action.",
+    "callToAction": "See tooltips in action"
+  },
+  "embeds": {
+    "title": "Embeds",
+    "overview": "Inject seamless-looking experiences inline alongside your other app content.",
+    "callToAction": "See an embed in action"
+  },
+  "preview": {
+    "p1": "The Appcues Mobile Builder allows you to easily use a deep link to preview your flows in your app:",
+    "p2": "If you don't have the Appcues Mobile SDK installed in your app, this app allows you to test out your flow."
+  },
+  "more": {
+    "signOut": "Sign Out",
+    "debugger": "The Appcues debugger is an in-app overlay that provides debug information in an accessible manner.",
+    "debuggerButton": "Launch the debugger",
+    "colophon": "This app is created using React Native, Expo, and the Appcues Mobile SDK.",
+    "sourceLink": "MIT Licensed and source available."
+  }
+}

--- a/languages/french.json
+++ b/languages/french.json
@@ -1,0 +1,56 @@
+{
+  "signIn": {
+    "title": "Vitrine de motifs mobile",
+    "input": "Email de travail",
+    "inputError": "Veuillez entrer votre adresse e-mail.",
+    "button": "Continuer"
+  },
+  "tabs": {
+    "patterns": "Motifs",
+    "examples": "Exemples",
+    "preview": "Aperçu",
+    "more": "Plus"
+  },
+  "patterns": {
+    "list": {
+      "modals": {
+        "title": "Modals",
+        "subtitle": "Utilisez des captures partielles et plein écran pour transmettre des informations de marque."
+      },
+      "tooltips": {
+        "title": "Tooltips",
+        "subtitle": "Mettez en surbrillance des éléments spécifiques de l'application pour attirer l'attention des utilisateurs et inciter à l'action."
+      },
+      "embeds": {
+        "title": "Embeds",
+        "subtitle": "Injectez des expériences fluides en ligne avec le contenu de votre autre application."
+      }
+    }
+  },
+  "modals": {
+    "title": "Modals",
+    "overview": "Utilisez des captures partielles et plein écran pour transmettre des informations de marque.",
+    "callToAction": "Voir un modal en action"
+  },
+  "tooltips": {
+    "title": "Tooltips",
+    "overview": "Mettez en surbrillance des éléments spécifiques de l'application pour attirer l'attention des utilisateurs et inciter à l'action.",
+    "callToAction": "Voir les tooltips en action"
+  },
+  "embeds": {
+    "title": "Embeds",
+    "overview": "Injectez des expériences fluides en ligne avec le contenu de votre autre application.",
+    "callToAction": "Voir un embed en action"
+  },
+  "preview": {
+    "p1": "L'Appcues Mobile Builder vous permet d'utiliser facilement un lien profond pour prévisualiser vos flux dans votre application :",
+    "p2": "Si le SDK Appcues Mobile n'est pas installé dans votre application, cette application vous permet de tester votre flux."
+  },
+  "more": {
+    "signOut": "Se déconnecter",
+    "debugger": "Le débogueur Appcues est une superposition intégrée à l'application qui fournit des informations de débogage de manière accessible.",
+    "debuggerButton": "Lancez le débogueur",
+    "colophon": "Cette application est créée à l'aide de React Native, Expo et du SDK Appcues Mobile.",
+    "sourceLink": "Licence MIT et source disponible."
+  }
+}

--- a/languages/spanish.json
+++ b/languages/spanish.json
@@ -1,0 +1,56 @@
+{
+  "signIn": {
+    "title": "Escaparate de patrones móviles",
+    "input": "Correo electrónico del trabajo",
+    "inputError": "Por favor, introduzca su dirección de correo electrónico.",
+    "button": "Continuar"
+  },
+  "tabs": {
+    "patterns": "Patrones",
+    "examples": "Ejemplos",
+    "preview": "Avance",
+    "more": "Más"
+  },
+  "patterns": {
+    "list": {
+      "modals": {
+        "title": "Modals",
+        "subtitle": "Utilice tomas de control parciales y de pantalla completa para transmitir información de marca."
+      },
+      "tooltips": {
+        "title": "Tooltips",
+        "subtitle": "Resalte elementos específicos de la aplicación para llamar la atención del usuario y estimular la acción."
+      },
+      "embeds": {
+        "title": "Embeds",
+        "subtitle": "Inyecte experiencias fluidas en línea junto con el resto del contenido de su aplicación."
+      }
+    }
+  },
+  "modals": {
+    "title": "Modals",
+    "overview": "Utilice tomas de control parciales y de pantalla completa para transmitir información de marca.",
+    "callToAction": "Vea un modal en acción"
+  },
+  "tooltips": {
+    "title": "Tooltips",
+    "overview": "Resalte elementos específicos de la aplicación para llamar la atención del usuario y estimular la acción.",
+    "callToAction": "Vea la tooltip en acción"
+  },
+  "embeds": {
+    "title": "Embeds",
+    "overview": "Inyecte experiencias fluidas en línea junto con el resto del contenido de su aplicación.",
+    "callToAction": "Vea un embed en acción"
+  },
+  "preview": {
+    "p1": "Appcues Mobile Builder le permite utilizar fácilmente un enlace profundo para obtener una vista previa de sus flujos en su aplicación:",
+    "p2": "Si no tiene instalado el SDK de Appcues Mobile en su aplicación, esta aplicación le permite probar su flujo."
+  },
+  "more": {
+    "signOut": "Desconectar",
+    "debugger": "El depurador de Appcues es una superposición en la aplicación que proporciona información de depuración de forma accesible.",
+    "debuggerButton": "Inicie el depurador",
+    "colophon": "Esta aplicación se crea utilizando React Native, Expo y Appcues Mobile SDK.",
+    "sourceLink": "Con licencia del MIT y fuente disponible."
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "appcues-mobile-showcase",
       "version": "1.0.1",
       "dependencies": {
-        "@appcues/react-native": "^3.1.4",
+        "@appcues/react-native": "^3.1.6",
         "@expo/vector-icons": "^13.0.0",
         "@react-navigation/native": "^6.0.2",
         "appcues-custom-previewer": "./packages/appcues-custom-previewer",
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@appcues/react-native": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-3.1.4.tgz",
-      "integrity": "sha512-XbYjgzLwvUvHT+gVkmVMFXeCTVOm3TsvzHzJ0uc5n1U3quqrkutjjxSBjGoMDTkJIGbuk8/VCkvTHy3KAe0WTA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-3.1.6.tgz",
+      "integrity": "sha512-ZzgVhqcFtc5MTkLaIXjYGuuHsqEGPtL6aZOqwe/93DVU2yqALYSwf30Z4KvyRKHRhcShKjKEPePa2NBFqK22dQ==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -21392,9 +21392,9 @@
       }
     },
     "@appcues/react-native": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-3.1.4.tgz",
-      "integrity": "sha512-XbYjgzLwvUvHT+gVkmVMFXeCTVOm3TsvzHzJ0uc5n1U3quqrkutjjxSBjGoMDTkJIGbuk8/VCkvTHy3KAe0WTA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-3.1.6.tgz",
+      "integrity": "sha512-ZzgVhqcFtc5MTkLaIXjYGuuHsqEGPtL6aZOqwe/93DVU2yqALYSwf30Z4KvyRKHRhcShKjKEPePa2NBFqK22dQ==",
       "requires": {}
     },
     "@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "appcues-custom-previewer": "./packages/appcues-custom-previewer",
         "expo": "~49.0.8",
         "expo-build-properties": "~0.8.3",
-        "expo-dev-client": "~2.4.11",
+        "expo-dev-client": "~2.4.12",
         "expo-font": "~11.4.0",
         "expo-linear-gradient": "~12.3.0",
         "expo-linking": "~5.0.2",
@@ -11008,12 +11008,12 @@
       }
     },
     "node_modules/expo-dev-client": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-2.4.11.tgz",
-      "integrity": "sha512-A7aKQZeEYG0YJ51GnjOFkMNe118jD1cbU+v5iM3E+H1Co5aVtnlGZWcv8Dtw3uGuWxRgbWGds5TGNbcDmJ1hDg==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-2.4.12.tgz",
+      "integrity": "sha512-3+xg0yb/0g6+JQaWq5+xn2uHoOXP4oSX33aWkaZPSNJLoyzfRaHNDF5MLcrMBbEHCw5T5qZRU291K+uQeMMC0g==",
       "dependencies": {
-        "expo-dev-launcher": "2.4.13",
-        "expo-dev-menu": "3.2.1",
+        "expo-dev-launcher": "2.4.14",
+        "expo-dev-menu": "3.2.2",
         "expo-dev-menu-interface": "1.3.0",
         "expo-manifests": "~0.7.0",
         "expo-updates-interface": "~0.10.0"
@@ -11023,11 +11023,11 @@
       }
     },
     "node_modules/expo-dev-launcher": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-2.4.13.tgz",
-      "integrity": "sha512-afszaREyGnhWJMmcOuDGs83r0UWeRvZrOHlKQxxst/UhAeFQqlDmkEjwtDWfTUy7BoXuuw2CuQtUFH+vTyjEGA==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-2.4.14.tgz",
+      "integrity": "sha512-SlUf+fEX9sKzDzY1Ui8j5775eLKpO0xPVoI89G7CRsrpUv6ZRvRF836cMFesxkU5d+3bXHpKzDQiEPDSI1G/WQ==",
       "dependencies": {
-        "expo-dev-menu": "3.2.1",
+        "expo-dev-menu": "3.2.2",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3"
       },
@@ -11066,9 +11066,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/expo-dev-menu": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-3.2.1.tgz",
-      "integrity": "sha512-SxH/ZUIYZliMBjJTpiECVSDkP7e81mbGNLH8ZD69iCAfLeH7P1OPXFycEdcvN33I7tVqzFgARGLK/W/8JV+U9w==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-3.2.2.tgz",
+      "integrity": "sha512-q0IDlCGkZMsDIFV+Mgnz0Q3u/bcnrF8IFMglJ0onF09e5csLk5Ts7hKoQyervOJeThyI402r9OQsFNaru2tgtg==",
       "dependencies": {
         "expo-dev-menu-interface": "1.3.0",
         "semver": "^7.5.3"
@@ -29302,23 +29302,23 @@
       }
     },
     "expo-dev-client": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-2.4.11.tgz",
-      "integrity": "sha512-A7aKQZeEYG0YJ51GnjOFkMNe118jD1cbU+v5iM3E+H1Co5aVtnlGZWcv8Dtw3uGuWxRgbWGds5TGNbcDmJ1hDg==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-2.4.12.tgz",
+      "integrity": "sha512-3+xg0yb/0g6+JQaWq5+xn2uHoOXP4oSX33aWkaZPSNJLoyzfRaHNDF5MLcrMBbEHCw5T5qZRU291K+uQeMMC0g==",
       "requires": {
-        "expo-dev-launcher": "2.4.13",
-        "expo-dev-menu": "3.2.1",
+        "expo-dev-launcher": "2.4.14",
+        "expo-dev-menu": "3.2.2",
         "expo-dev-menu-interface": "1.3.0",
         "expo-manifests": "~0.7.0",
         "expo-updates-interface": "~0.10.0"
       }
     },
     "expo-dev-launcher": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-2.4.13.tgz",
-      "integrity": "sha512-afszaREyGnhWJMmcOuDGs83r0UWeRvZrOHlKQxxst/UhAeFQqlDmkEjwtDWfTUy7BoXuuw2CuQtUFH+vTyjEGA==",
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-2.4.14.tgz",
+      "integrity": "sha512-SlUf+fEX9sKzDzY1Ui8j5775eLKpO0xPVoI89G7CRsrpUv6ZRvRF836cMFesxkU5d+3bXHpKzDQiEPDSI1G/WQ==",
       "requires": {
-        "expo-dev-menu": "3.2.1",
+        "expo-dev-menu": "3.2.2",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3"
       },
@@ -29347,9 +29347,9 @@
       }
     },
     "expo-dev-menu": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-3.2.1.tgz",
-      "integrity": "sha512-SxH/ZUIYZliMBjJTpiECVSDkP7e81mbGNLH8ZD69iCAfLeH7P1OPXFycEdcvN33I7tVqzFgARGLK/W/8JV+U9w==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-3.2.2.tgz",
+      "integrity": "sha512-q0IDlCGkZMsDIFV+Mgnz0Q3u/bcnrF8IFMglJ0onF09e5csLk5Ts7hKoQyervOJeThyI402r9OQsFNaru2tgtg==",
       "requires": {
         "expo-dev-menu-interface": "1.3.0",
         "semver": "^7.5.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcues-mobile-showcase",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appcues-mobile-showcase",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@appcues/react-native": "^3.1.4",
         "@expo/vector-icons": "^13.0.0",
@@ -18,6 +18,7 @@
         "expo-font": "~11.4.0",
         "expo-linear-gradient": "~12.3.0",
         "expo-linking": "~5.0.2",
+        "expo-localization": "~14.3.0",
         "expo-router": "2.0.4",
         "expo-splash-screen": "~0.20.5",
         "expo-status-bar": "~1.6.0",
@@ -11183,6 +11184,17 @@
         "url-parse": "^1.5.9"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-14.3.0.tgz",
+      "integrity": "sha512-TML3TeVtwpfuSNwbhBspC9XsGJaa0TWJNh+UaR/35YP9fQiaJfVWUMSrAq84ba6rY1Pm3kti07LV8UUa505oqg==",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-manifests": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.7.2.tgz",
@@ -19171,6 +19183,11 @@
       "bin": {
         "rimraf": "bin.js"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ=="
     },
     "node_modules/run-applescript": {
       "version": "5.0.0",
@@ -29420,6 +29437,14 @@
         "url-parse": "^1.5.9"
       }
     },
+    "expo-localization": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-14.3.0.tgz",
+      "integrity": "sha512-TML3TeVtwpfuSNwbhBspC9XsGJaa0TWJNh+UaR/35YP9fQiaJfVWUMSrAq84ba6rY1Pm3kti07LV8UUa505oqg==",
+      "requires": {
+        "rtl-detect": "^1.0.2"
+      }
+    },
     "expo-manifests": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.7.2.tgz",
@@ -35267,6 +35292,11 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ=="
     },
     "run-applescript": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "appcues-custom-previewer": "./packages/appcues-custom-previewer",
     "expo": "~49.0.8",
     "expo-build-properties": "~0.8.3",
-    "expo-dev-client": "~2.4.11",
+    "expo-dev-client": "~2.4.12",
     "expo-font": "~11.4.0",
     "expo-linear-gradient": "~12.3.0",
     "expo-linking": "~5.0.2",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,16 @@
   },
   "dependencies": {
     "@appcues/react-native": "^3.1.4",
-    "appcues-custom-previewer": "./packages/appcues-custom-previewer",
     "@expo/vector-icons": "^13.0.0",
     "@react-navigation/native": "^6.0.2",
+    "appcues-custom-previewer": "./packages/appcues-custom-previewer",
     "expo": "~49.0.8",
+    "expo-build-properties": "~0.8.3",
+    "expo-dev-client": "~2.4.11",
     "expo-font": "~11.4.0",
     "expo-linear-gradient": "~12.3.0",
     "expo-linking": "~5.0.2",
+    "expo-localization": "~14.3.0",
     "expo-router": "2.0.4",
     "expo-splash-screen": "~0.20.5",
     "expo-status-bar": "~1.6.0",
@@ -35,9 +38,7 @@
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",
-    "react-native-web": "~0.19.6",
-    "expo-dev-client": "~2.4.11",
-    "expo-build-properties": "~0.8.3"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@appcues/react-native": "^3.1.4",
+    "@appcues/react-native": "^3.1.6",
     "@expo/vector-icons": "^13.0.0",
     "@react-navigation/native": "^6.0.2",
     "appcues-custom-previewer": "./packages/appcues-custom-previewer",


### PR DESCRIPTION
Rolled my own `LocaleProvider` since the [Expo recommended](https://docs.expo.dev/guides/localization/#translating-an-app) `i18n-js` seemed like overkill. Took some time to figure out, but all the strings are type safe, which is cool.

The general recipe is:
1. `import { useLocale } from '../../../context/locale';`
2. `const { language, strings } = useLocale();`
3. Use `strings[language].xyz`

New languages can be added in the `locale.tsx` `supportedLanguages` object. The French copy is all Google translated. I opted against translating pattern types like "Modal", "Tooltip", or "Embed".

Using the `Localization.useLocales()` hook means that the UI will update for the Android case where the language changes while the app is running. This is likely more important in our case compared to general purpose apps, since people will be more likely to change the language specifically to test our localization functionality.

https://www.seeratawan.me/blog/react-internationalization-using-context-api/ was a helpful blog post in sorting the context stuff out.

I've also updated the display name of the app from "Showcase" to "Appcues". I didn't want to change the expo project name, so that means setting `CFBundleDisplayName` directly for iOS. There's not really a solution for Android, so I resorted to a post-build hack.