### PR TITLE
Fix iOS localization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Appcues
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app.json
+++ b/app.json
@@ -30,7 +30,6 @@
         "usesNonExemptEncryption": false
       },
       "infoPlist": {
-        "CFBundleDisplayName": "Appcues",
         "CFBundleAllowMixedLocalizations": true,
         "AppcuesUniversalLinkHostAllowList": []
       }
@@ -46,6 +45,12 @@
       "bundler": "metro",
       "output": "static",
       "favicon": "./assets/images/favicon.png"
+    },
+    "locales": {
+      "en": "./languages/info-en.json",
+      "fr": "./languages/info-fr.json",
+      "pt": "./languages/info-pt.json",
+      "es": "./languages/info-es.json"
     },
     "plugins": [
       "expo-router",

--- a/app/(tabs)/more/index.tsx
+++ b/app/(tabs)/more/index.tsx
@@ -48,11 +48,7 @@ export default function Examples() {
           title={strings[language].more.debuggerButton}
         />
       </View>
-      <View
-        style={styles.card}
-        level="secondaryBackground"
-        testID="debugger-card"
-      >
+      <View style={styles.card} level="secondaryBackground" testID="demo-card">
         <Text>{strings[language].more.demo}</Text>
         <PrimaryButton
           onPress={() => {

--- a/languages/info-en.json
+++ b/languages/info-en.json
@@ -1,0 +1,3 @@
+{
+  "CFBundleDisplayName": "Appcues"
+}

--- a/languages/info-es.json
+++ b/languages/info-es.json
@@ -1,0 +1,3 @@
+{
+  "CFBundleDisplayName": "Appcues"
+}

--- a/languages/info-fr.json
+++ b/languages/info-fr.json
@@ -1,0 +1,3 @@
+{
+  "CFBundleDisplayName": "Appcues"
+}

--- a/languages/info-pt.json
+++ b/languages/info-pt.json
@@ -1,0 +1,3 @@
+{
+  "CFBundleDisplayName": "Appcues"
+}


### PR DESCRIPTION
`_lastBrowserLanguage` wasn't updating as expected for iOS builds from EAS. Digging into it, it appears that not having a `locales` key in the `app.json` means there’s no language `.lproj` being added to the iOS bundle. I didn't have it since there's currently no `Info.plist` metadata to translate (since the app display name is just “Appcues” in all languages), but that meant that `Bundle.preferredLocalizations` wasn't picking up the locale. Adding locales with some `Info.plist` data and `CFBundleDisplayName` seems to fix that, and we'll need more localization in the future for notification permissions, etc.

Plus fixing a duplicate `testID` that was breaking the onboarding tour and adding a license file since Andre pointed out that was missing.