### PR TITLE
Fix pattern back button navigation

### DIFF
--- a/app/(tabs)/patterns/index.tsx
+++ b/app/(tabs)/patterns/index.tsx
@@ -1,4 +1,3 @@
-import { router } from 'expo-router';
 import { FlatList, ImageSourcePropType, StyleSheet } from 'react-native';
 
 import { WrappedAppcuesFrameView } from '../../../components/AppcuesWrapper';
@@ -35,7 +34,7 @@ export default function Patterns() {
         image={item.image}
         title={strings[language].patterns.list[item.slug].title}
         subtitle={strings[language].patterns.list[item.slug].subtitle}
-        onPress={() => router.push(`/patterns/${item.slug}`)}
+        href={`/patterns/${item.slug}`}
         testID={`${item.slug}-card`}
         style={{
           marginBottom: 20,

--- a/components/PatternCard.tsx
+++ b/components/PatternCard.tsx
@@ -1,5 +1,5 @@
+import { Href, Link } from 'expo-router';
 import {
-  GestureResponderEvent,
   Image,
   ImageSourcePropType,
   StyleSheet,
@@ -15,28 +15,29 @@ type PatternCardProps = {
   image: ImageSourcePropType;
   title: string;
   subtitle: string;
+  href: Href<string>;
   style?: ViewStyle;
-  onPress?: ((event: GestureResponderEvent) => void) | undefined;
   testID?: string;
 };
 
 export default function PatternCard(props: PatternCardProps) {
   return (
-    <TouchableHighlight
-      style={{ ...styles.container, ...props.style }}
-      onPress={props.onPress}
-      testID={props.testID}
-    >
-      <ThemedView style={styles.inner} level="secondaryBackground">
-        <Image source={props.image} style={styles.image} />
-        <View style={styles.detail}>
-          <Text style={styles.title}>{props.title}</Text>
-          <Text style={styles.subtitle} level="tertiaryForeground">
-            {props.subtitle}
-          </Text>
-        </View>
-      </ThemedView>
-    </TouchableHighlight>
+    <Link href={props.href} asChild>
+      <TouchableHighlight
+        style={{ ...styles.container, ...props.style }}
+        testID={props.testID}
+      >
+        <ThemedView style={styles.inner} level="secondaryBackground">
+          <Image source={props.image} style={styles.image} />
+          <View style={styles.detail}>
+            <Text style={styles.title}>{props.title}</Text>
+            <Text style={styles.subtitle} level="tertiaryForeground">
+              {props.subtitle}
+            </Text>
+          </View>
+        </ThemedView>
+      </TouchableHighlight>
+    </Link>
   );
 }
 


### PR DESCRIPTION
`router.push` has apparently changed in Expo 50/router 3? Using `<Link asChild>` instead.

ref: https://docs.expo.dev/router/navigating-pages/#buttons

thread: https://appcues.slack.com/archives/C031RLGS4F8/p1706558105632309