### PR TITLE
Update AppcuesCustomPreviewer to support new arch

### DIFF
--- a/packages/appcues-custom-previewer/android/build.gradle
+++ b/packages/appcues-custom-previewer/android/build.gradle
@@ -58,6 +58,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())
 
   }
 
@@ -74,6 +75,16 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+  sourceSets {
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += ["src/newarch"]
+      } else {
+        java.srcDirs += ["src/oldarch"]
+      }
+    }
   }
 }
 

--- a/packages/appcues-custom-previewer/android/src/main/java/com/appcuescustompreviewer/AppcuesCustomPreviewerModule.kt
+++ b/packages/appcues-custom-previewer/android/src/main/java/com/appcuescustompreviewer/AppcuesCustomPreviewerModule.kt
@@ -4,39 +4,36 @@ import android.content.Intent
 import android.net.Uri
 import com.appcues.Appcues
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
 
-class AppcuesCustomPreviewerModule(reactContext: ReactApplicationContext) :
-  ReactContextBaseJavaModule(reactContext) {
+class AppcuesCustomPreviewerModule internal constructor(private val context: ReactApplicationContext) :
+  AppcuesCustomPreviewerSpec(context) {
 
   override fun getName(): String {
-    return "AppcuesCustomPreviewer"
+    return NAME
   }
 
   @ReactMethod
-  fun preview(accountID: String, applicationID: String, experienceID: String, localeID: String?, promise: Promise) {
-    val context = reactApplicationContextIfActiveOrWarn
-    if (context == null) {
-      promise.reject("Preview Failure", "Unable to initialize the SDK, no Application Context found")
-      return
-    }
-
+  override fun preview(accountID: String, applicationID: String, experienceID: String, localeID: String?, promise: Promise) {
     val previewInstance = Appcues(context, accountID, applicationID)
 
-    val activity = currentActivity
+    val activity = context.currentActivity
 
     val localeParam = localeID?.let { "?locale_id=$it" } ?: ""
 
     val deepLink = "appcues-$applicationID://sdk/experience_preview/$experienceID$localeParam"
     val uri = Uri.parse(deepLink)
     if (activity != null) {
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = uri
-        promise.resolve(previewInstance.onNewIntent(activity, intent) ?: false)
+      val intent = Intent(Intent.ACTION_VIEW)
+      intent.data = uri
+      promise.resolve(previewInstance.onNewIntent(activity, intent))
     } else {
       promise.reject("Preview Failure", "Unable to handle the URL, no current running Activity found")
     }
+  }
+
+  companion object {
+    const val NAME = "AppcuesCustomPreviewer"
   }
 }

--- a/packages/appcues-custom-previewer/android/src/main/java/com/appcuescustompreviewer/AppcuesCustomPreviewerPackage.kt
+++ b/packages/appcues-custom-previewer/android/src/main/java/com/appcuescustompreviewer/AppcuesCustomPreviewerPackage.kt
@@ -1,17 +1,31 @@
 package com.appcuescustompreviewer
 
-import com.facebook.react.ReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 
+class AppcuesCustomPreviewerPackage : TurboReactPackage() {
 
-class AppcuesCustomPreviewerPackage : ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-    return listOf(AppcuesCustomPreviewerModule(reactContext))
+  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+    return if (name == AppcuesCustomPreviewerModule.NAME) {
+      AppcuesCustomPreviewerModule(reactContext)
+    } else {
+      null
+    }
   }
 
-  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-    return emptyList()
+  override fun getReactModuleInfoProvider() = ReactModuleInfoProvider {
+    mapOf(
+      AppcuesCustomPreviewerModule.NAME to ReactModuleInfo(
+        _name = AppcuesCustomPreviewerModule.NAME,
+        _className = AppcuesCustomPreviewerModule.NAME,
+        _canOverrideExistingModule = false,
+        _needsEagerInit = false,
+        isCxxModule = false,
+        isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+      )
+    )
   }
 }

--- a/packages/appcues-custom-previewer/android/src/newarch/AppcuesCustomPreviewerSpec.kt
+++ b/packages/appcues-custom-previewer/android/src/newarch/AppcuesCustomPreviewerSpec.kt
@@ -1,0 +1,7 @@
+package com.appcuescustompreviewer
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+abstract class AppcuesCustomPreviewerSpec internal constructor(reactContext: ReactApplicationContext) :
+  NativeAppcuesCustomPreviewerSpec(reactContext) {
+}

--- a/packages/appcues-custom-previewer/android/src/oldarch/AppcuesCustomPreviewerSpec.kt
+++ b/packages/appcues-custom-previewer/android/src/oldarch/AppcuesCustomPreviewerSpec.kt
@@ -1,0 +1,11 @@
+package com.appcuescustompreviewer
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.Promise
+
+abstract class AppcuesCustomPreviewerSpec internal constructor(reactContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactContext) {
+
+  abstract fun preview(accountID: String, applicationID: String, experienceID: String, localeID: String?, promise: Promise)
+}

--- a/packages/appcues-custom-previewer/appcues-custom-previewer.podspec
+++ b/packages/appcues-custom-previewer/appcues-custom-previewer.podspec
@@ -15,6 +15,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency "React-Core"
+  # React Native Core dependency
+  install_modules_dependencies(s)
+
   s.dependency "Appcues"
 end

--- a/packages/appcues-custom-previewer/index.js
+++ b/packages/appcues-custom-previewer/index.js
@@ -2,8 +2,14 @@ import { NativeModules } from 'react-native';
 
 const LINKING_ERROR = `The package 'appcues-custom-previewer' doesn't seem to be linked.`;
 
-const AppcuesCustomPreviewer = NativeModules.AppcuesCustomPreviewer
-  ? NativeModules.AppcuesCustomPreviewer
+const isTurboModuleEnabled = global.__turboModuleProxy != null;
+
+const Module = isTurboModuleEnabled
+  ? require('./specs/NativeAppcuesCustomPreviewer').default
+  : NativeModules.AppcuesCustomPreviewer;
+
+const AppcuesCustomPreviewer = Module
+  ? Module
   : new Proxy(
       {},
       {

--- a/packages/appcues-custom-previewer/ios/AppcuesCustomPreviewer-Bridging-Header.h
+++ b/packages/appcues-custom-previewer/ios/AppcuesCustomPreviewer-Bridging-Header.h
@@ -1,2 +1,1 @@
 #import <React/RCTBridgeModule.h>
-#import <React/RCTViewManager.h>

--- a/packages/appcues-custom-previewer/ios/AppcuesCustomPreviewer.mm
+++ b/packages/appcues-custom-previewer/ios/AppcuesCustomPreviewer.mm
@@ -1,6 +1,11 @@
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <AppcuesCustomPreviewerSpec/AppcuesCustomPreviewerSpec.h>
+@interface RCT_EXTERN_MODULE(AppcuesCustomPreviewer, NativeAppcuesCustomPreviewerSpecBase)
+#else
 @interface RCT_EXTERN_MODULE(AppcuesCustomPreviewer, NSObject)
+#endif
 
 RCT_EXTERN_METHOD(preview:(NSString)accountID
                   applicationID:(NSString)applicationID
@@ -9,9 +14,12 @@ RCT_EXTERN_METHOD(preview:(NSString)accountID
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
-+ (BOOL)requiresMainQueueSetup
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
 {
-  return NO;
+    return std::make_shared<facebook::react::NativeAppcuesCustomPreviewerSpecJSI>(params);
 }
+#endif
 
 @end

--- a/packages/appcues-custom-previewer/package.json
+++ b/packages/appcues-custom-previewer/package.json
@@ -5,5 +5,13 @@
   "main": "index.js",
   "author": "Appcues <mobile@appcues.com> (https://www.appcues.com)",
   "license": "MIT",
-  "homepage": "https://github.com/appcues/mobile-pattern-showcase-app#readme"
+  "homepage": "https://github.com/appcues/mobile-pattern-showcase-app#readme",
+  "codegenConfig": {
+    "name": "AppcuesCustomPreviewerSpec",
+    "type": "modules",
+    "jsSrcsDir": "specs",
+    "android": {
+      "javaPackageName": "com.appcuescustompreviewer"
+    }
+  }
 }

--- a/packages/appcues-custom-previewer/specs/NativeAppcuesCustomPreviewer.ts
+++ b/packages/appcues-custom-previewer/specs/NativeAppcuesCustomPreviewer.ts
@@ -1,0 +1,13 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  preview(
+    accountID: string,
+    applicationID: string,
+    experienceID: string,
+    localeID: string
+  ): Promise<boolean>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('AppcuesCustomPreviewer');


### PR DESCRIPTION
I recommend reading the first doc linked below to get a sense of what's happening here. The actual implementation is a bit more complex since I wanted to make it backwards compatible, which is described in the second doc below. At a high level it's:

1. Add a typed specification (`specs/NativeAppcuesCustomPreviewer.ts`)
2. Configure codegen (`package.json`)
3. Interchangeably
    - Update the JS (`index.js`) to switch between the old arch and new arch
    - Update the Obj-c code (`ios/AppcuesCustomPreviewer.mm`) to use the generated `NativeAppcuesCustomPreviewerSpecBase`
    - Update Build.gradle to swap between old/new arch, update the Kotlin code (`android/.../AppcuesCustomPreviewerModule.kt`) to use the generated `NativeAppcuesCustomPreviewerSpec`, and update the package to a `TurboReactPackage`.

Docs that were helpful:
1. [Native Modules](https://reactnative.dev/docs/turbo-native-modules-introduction?platforms=android#4-write-your-native-platform-code) and [Create a Library for Your Module](https://reactnative.dev/docs/the-new-architecture/create-module-library)
    - I frequently referenced the template generated by `npx create-react-native-library@latest`, but generally maintained a simpler approach here since this is such a basic module
1. [Turbo Modules as Legacy Native Modules](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/backwards-compat-turbo-modules.md#update-the-codebase-1)
    - I modified the recommended android approach to use an abstract class to reduce some repetition, inspired by the [RateApp package](https://github.com/huextrat/react-native-rate-app/blob/main/android/src/main/java/com/rateapp/RateAppModule.kt). @andretortolano I'd love a critical eye on the Kotlin code—there's lots of different ways to do the same thing, so I'll take any best practice suggestions you have
1. [Using Codegen](https://reactnative.dev/docs/the-new-architecture/using-codegen)

Notes:
1. The use of `install_modules_dependencies(s)` in the Podspec is supported by RN 0.71+. This limitation can be removed for additional backwards compatibility if needed:
    ```rb
    if respond_to?(:install_modules_dependencies, true)
        install_modules_dependencies(s)
    else
        # everything that used to be here
    end
    ```
2. There's a codegen option `"includesGeneratedCode": true` that [includes the generated code in the library](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/codegen.md#including-generated-code-into-libraries) instead of relying on the host app to generate it. This generally seems advantageous, but whenever I tried it, the iOS compilation would fail because of the Swift implementation.