### PR TITLE
Update @appcues/react-native to 5.0.5

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Showcase",
     "slug": "appcues-mobile-showcase",
     "owner": "appcues",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.15",
       "dependencies": {
         "@appcues/expo-config": "^4.0.1",
-        "@appcues/react-native": "^5.0.0",
+        "@appcues/react-native": "^5.0.5",
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/native": "^7.0.0",
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@appcues/react-native": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.0.tgz",
-      "integrity": "sha512-56rvQg/3jUBDXwXxD3gVJPBeWa52MsuEvZMV59sQcm7SKBBbM3Sx/fx2SVRCgGMmQuA3JQeh1qn7UnzzF/xXWQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.5.tgz",
+      "integrity": "sha512-zLVZ7Em7LalhX5E8tW1jGK3o8mIxnzDxHN6zEJvLITyJNivP4dRK1wfB7Qh12N/5k/r43hqnPuJm5ZY+cVth3Q==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -17144,9 +17144,9 @@
       "requires": {}
     },
     "@appcues/react-native": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.0.tgz",
-      "integrity": "sha512-56rvQg/3jUBDXwXxD3gVJPBeWa52MsuEvZMV59sQcm7SKBBbM3Sx/fx2SVRCgGMmQuA3JQeh1qn7UnzzF/xXWQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.5.tgz",
+      "integrity": "sha512-zLVZ7Em7LalhX5E8tW1jGK3o8mIxnzDxHN6zEJvLITyJNivP4dRK1wfB7Qh12N/5k/r43hqnPuJm5ZY+cVth3Q==",
       "requires": {}
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appcues-mobile-showcase",
   "main": "expo-router/entry",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@appcues/expo-config": "^4.0.1",
-    "@appcues/react-native": "^5.0.0",
+    "@appcues/react-native": "^5.0.5",
     "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/native": "^7.0.0",


### PR DESCRIPTION
## Summary
- Upgrades `@appcues/react-native` from `5.0.0` to `5.0.5`

## Test plan
- [ ] Build on iOS and Android via EAS
- [ ] Verify Appcues SDK initializes correctly
- [ ] Confirm flows render as expected


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped app version to 1.0.16 (user-facing build/version update).
  * Updated a third-party in-app guidance library to a newer patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->