### PR TITLE
Fix SDK 56 regressions: previewer linking and splash screen

### DIFF
--- a/app.json
+++ b/app.json
@@ -79,8 +79,8 @@
         "expo-splash-screen",
         {
           "image": "./assets/images/splash.png",
-          "resizeMode": "contain",
           "backgroundColor": "#ffffff",
+          "enableFullScreenImage_legacy": true,
           "dark": {
             "image": "./assets/images/splash-dark.png",
             "backgroundColor": "#0B1A38"

--- a/packages/appcues-custom-previewer/index.js
+++ b/packages/appcues-custom-previewer/index.js
@@ -1,12 +1,6 @@
-import { NativeModules } from 'react-native';
-
 const LINKING_ERROR = `The package 'appcues-custom-previewer' doesn't seem to be linked.`;
 
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
-
-const Module = isTurboModuleEnabled
-  ? require('./specs/NativeAppcuesCustomPreviewer').default
-  : NativeModules.AppcuesCustomPreviewer;
+const Module = require('./specs/NativeAppcuesCustomPreviewer').default;
 
 const AppcuesCustomPreviewer = Module
   ? Module


### PR DESCRIPTION
## Summary
- Fix custom previewer TurboModule not linking in RN 0.85 (`global.__turboModuleProxy` removed, always use TurboModule path)
- Restore full-screen splash image via `enableFullScreenImage_legacy` (SDK 56 plugin defaults to small centered icon)

## Test plan
- [x] iOS simulator build succeeds
- [x] Splash screen displays at correct size
- [ ] Previewer deep link test on real device


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated splash screen configuration to support legacy full-screen image display mode, enhancing visual compatibility across various device configurations.
  * Refactored internal module initialization logic to improve code maintainability while ensuring all existing functionality remains fully intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->