### PR TITLE
Fix Android build: scope locale keys to iOS platform

### DIFF
--- a/languages/info-ar.json
+++ b/languages/info-ar.json
@@ -1,3 +1,5 @@
 {
-  "CFBundleDisplayName": "Appcues"
+  "ios": {
+    "CFBundleDisplayName": "Appcues"
+  }
 }

--- a/languages/info-en.json
+++ b/languages/info-en.json
@@ -1,3 +1,5 @@
 {
-  "CFBundleDisplayName": "Appcues"
+  "ios": {
+    "CFBundleDisplayName": "Appcues"
+  }
 }

--- a/languages/info-es.json
+++ b/languages/info-es.json
@@ -1,3 +1,5 @@
 {
-  "CFBundleDisplayName": "Appcues"
+  "ios": {
+    "CFBundleDisplayName": "Appcues"
+  }
 }

--- a/languages/info-fr.json
+++ b/languages/info-fr.json
@@ -1,3 +1,5 @@
 {
-  "CFBundleDisplayName": "Appcues"
+  "ios": {
+    "CFBundleDisplayName": "Appcues"
+  }
 }

--- a/languages/info-he.json
+++ b/languages/info-he.json
@@ -1,3 +1,5 @@
 {
-  "CFBundleDisplayName": "Appcues"
+  "ios": {
+    "CFBundleDisplayName": "Appcues"
+  }
 }

--- a/languages/info-pt.json
+++ b/languages/info-pt.json
@@ -1,3 +1,5 @@
 {
-  "CFBundleDisplayName": "Appcues"
+  "ios": {
+    "CFBundleDisplayName": "Appcues"
+  }
 }


### PR DESCRIPTION
## Summary
- Wrap `CFBundleDisplayName` in `"ios"` key in all locale files
- Fixes Android `ExtraTranslation` lint error on SDK 56 (iOS-only keys were leaking into Android string resources)

## Test plan
- [ ] EAS Android production build succeeds


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured language configuration files for improved platform-specific organization across multiple supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->